### PR TITLE
Use proper typographic apostrophes not primes

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
       <main>
          <p>Borrow books about design, technology and internet culture.</p>
          <p>We send them to you. You send them back when you're done.</p>
-         <p>We're currently building our library. Sign up to find out when we launch.</p>
+         <p>We’re currently building our library. Sign up to find out when we launch.</p>
 
 
          <!-- Begin MailChimp Signup Form -->
@@ -175,8 +175,8 @@
 
       </main>
       <footer>
-         <p>If you don't check the box above, we'll tell you when we launch, and you won't hear from us again after that</p>
-         <p>We'll send books all over the UK</p>
+         <p>If you don’t check the box above, we’ll tell you when we launch, and you won't hear from us again after that</p>
+         <p>We’ll send books all over the UK</p>
       </footer>
    </body>
 </html>


### PR DESCRIPTION
> “Smart quotes,” the correct quotation marks and apostrophes, are curly or sloped. "Dumb quotes," or straight quotes, are a vestigial constraint from typewriters when using one key for two different marks helped save space on a keyboard. Unfortunately, many improper marks make their way onto websites because of dumb defaults in applications and CMSs.

– http://smartquotesforsmartpeople.com/

This commit replaces an instance of a straight single quote used as an apostrophe ' with the unicode character for a proper typographic apostrophe ’.